### PR TITLE
fix `\newfontfamily` to work with XeLaTeX

### DIFF
--- a/academicons.sty
+++ b/academicons.sty
@@ -9,7 +9,7 @@
 
 \usepackage{fontspec}
 
-\newfontfamily{\AI}{academicons}
+\newfontfamily{\AI}{academicons.ttf}
 
 \newcommand*{\aiicon}[1]
   {\AI\csname aiicon@#1\endcsname}


### PR DESCRIPTION
originally reported in
https://tex.stackexchange.com/questions/296294/missing-font-with-academicons-sty/296300#296300